### PR TITLE
Write downloaded files atomically

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["development-tools::testing", "parsing"]
 [dependencies]
 ureq = "1.1"
 sha2 = "0.8"
+tempfile = "3.3.0"
 
 [build-dependencies]
 sha2 = "0.8"


### PR DESCRIPTION
Fixes #1.

- Save downloaded contents into a temporary file first, moving it after.
- Adjust tests to cover fetching the same file multiple times simultaneously.