### PR TITLE
Add GitHub Actions and support data set source URL override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: continuous integration
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  test:
+    name: Test (default)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          cache: true
+      # test Rust project
+      - run: cargo test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
+          cache: true
+      - run: cargo clippy
+        env:
+          RUSTFLAGS: -W warnings

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # DICOM Test Files
 
-This repository collects together example DICOM files from various sources. The intention is that they can be used
+[![dicom-test-files on crates.io](https://img.shields.io/crates/v/dicom-test-files.svg)](https://crates.io/crates/dicom-test-files)
+
+This repository collects together example DICOM files from various sources.
+The intention is that they can be used
 for testing across many different libraries.
+
+See the [documentation](https://docs.rs/dicom-test-files)
+for instructions of use.
 
 ## Known limitations
 
-The rust functions cannot be used from doc-tests as they are not executed from within
-the target directory.
+The Rust functions cannot be used from doc-tests
+as they are not executed from within the target directory.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,6 +18,27 @@
 //! # Ok(())
 //! # }
 //! ```
+//! 
+//! ## Source of data
+//! 
+//! By default,
+//! all data sets are hosted in
+//! the `dicom-test-files` project's [main repository][1],
+//! in the `data` folder.
+//! Inspect this folder to know what DICOM test files are available.
+//!
+//! To override this source,
+//! you can set the environment variable `DICOM_TEST_FILES_URL`
+//! to the base path of the data set's raw contents
+//! (usually ending with `data` or `data/`).
+//! 
+//! ```sh
+//! set DICOM_TEST_FILES_URL=https://raw.githubusercontent.com/Me/dicom-test-files/new/more-dicom/data
+//! cargo test
+//! ```
+//! 
+//! [1]: https://github.com/robyoung/dicom-test-files/tree/master/data
+
 #![deny(missing_docs)]
 
 use sha2::{Digest, Sha256};
@@ -57,10 +78,12 @@ impl From<io::Error> for Error {
     }
 }
 
-/// Return the local path for a given DICOM file
+/// Fetch a DICOM file by its relative path (`name`)
+/// if it has not been downloaded yet,
+/// and return its path in the local file system.
 ///
-/// This function will download and cache the file locally in `target/dicom_test_files`
-/// if it has not already been downloaded.
+/// This function will download and cache the file locally in
+/// `target/dicom_test_files`.
 pub fn path(name: &str) -> Result<PathBuf, Error> {
     let cached_path = get_data_path().join(name);
     if !cached_path.exists() {
@@ -69,10 +92,13 @@ pub fn path(name: &str) -> Result<PathBuf, Error> {
     Ok(cached_path)
 }
 
-/// Return a vector of local paths to all DICOM files
+/// Return a vector of local paths to all DICOM test files available.
 ///
-/// This function will download and cache the file locally in `target/dicom_test_files`
-/// if it has not already been downloaded.
+/// This function will download any test file not yet in the file system
+/// and cache the files locally to `target/dicom_test_files`.
+///
+/// Note that this operation may be unnecessarily expensive.
+/// Retrieving only the files that you need via [`path`] is preferred.
 pub fn all() -> Result<Vec<PathBuf>, Error> {
     FILE_HASHES
         .iter()


### PR DESCRIPTION
Hello again!

This PR brings some quality of life improvements to serve as a better foundation for extending the crate with more data sets in the future.

- Extended and reiterated on the readme and documentation so that it is easier to follow. 
- Updated the logic for building the base data set source URL so that it can run in CI, and can be overridden by consumers via environment variables.
- New GitHub Actions CI pipeline which runs the tests using the DICOM data contents from the branch itself.
